### PR TITLE
Fix: Typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ app.use(VueClipboard, {
 <script>
   export default {
     setup() {
-      const message = 'Hello Clipborad!'
+      const message = 'Hello Clipboard!'
       const onCopy = (e) => {
         alert('You just copied: ' + e.text)
       }
@@ -118,7 +118,7 @@ app.use(VueClipboard, {
   export default {
     setup() {
       const doCopy = () => {
-        copyText('Hello Clipborad', undefined, (error, event) => {
+        copyText('Hello Clipboard', undefined, (error, event) => {
           if (error) {
             alert('Can not copy')
             console.log(error)


### PR DESCRIPTION
I was reading the `readme.md` stumbled upon this. 