### PR TITLE
fix: pass VueClipboardConfig.autoSetContainer to container param

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ export default function (app, vueClipboardConfig) {
           action: function () {
             return binding.arg === 'cut' ? 'cut' : 'copy'
           },
-          container: vueClipboardConfig.autoSetContainer ? el : undefined,
+          container: VueClipboardConfig.autoSetContainer ? el : undefined,
         })
         clipboard.on('success', function (e) {
           var callback = el._vClipboard_success


### PR DESCRIPTION
If `vueClipboardConfig` is not passed. It will throw the following error. So, use `VueClipboardConfig` instead of `vueClipboardConfig` when pass variable in `container` parameter.

![image](https://github.com/Daizhen1995/vue3-clipboard/assets/21099079/89f90986-9a3c-4576-a429-25493ef8d184)
 